### PR TITLE
Update pluging-sharesite dependency

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -74,9 +74,10 @@ dependencies {
         exclude group: 'net.java.dev.jna', module: 'jna-platform'
     }
 
-    implementation ('com.github.desyncr:plugin-sharesite:0.4.7.4m') {
+    implementation ('com.github.desyncr:plugin-sharesite:0.4.7.6m') {
         exclude group: 'net.java.dev.jna', module: 'jna'
         exclude group: 'net.java.dev.jna', module: 'jna-platform'
+        exclude group: 'net.java', module: 'textile-j'
     }
 
     // For running a locally built freenet.jar

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -74,7 +74,7 @@ dependencies {
         exclude group: 'net.java.dev.jna', module: 'jna-platform'
     }
 
-    implementation ('com.github.desyncr:plugin-sharesite:0.4.7.6m') {
+    implementation ('com.github.desyncr:plugin-sharesite:0.4.7.7m') {
         exclude group: 'net.java.dev.jna', module: 'jna'
         exclude group: 'net.java.dev.jna', module: 'jna-platform'
         exclude group: 'net.java', module: 'textile-j'


### PR DESCRIPTION
Update Sharesite version. This version includes a workaround for Android to avoid silently failing due to lack of javax.imageio. It also includes changes to the default css styles to be mobile-friendly.


Fix #32 