### PR TITLE
Enforce threading when managing PowerConnectionReceiver

### DIFF
--- a/app/src/main/java/org/freenetproject/mobile/receivers/PowerConnectionReceiver.java
+++ b/app/src/main/java/org/freenetproject/mobile/receivers/PowerConnectionReceiver.java
@@ -20,11 +20,16 @@ public class PowerConnectionReceiver extends BroadcastReceiver {
         switch(Objects.requireNonNull(intent.getAction())){
             case Intent.ACTION_POWER_CONNECTED:
                 Log.i("Freenet", "Resuming service from power change");
-                Manager.getInstance().resumeService(context, Manager.CONTEXT_BATTERY);
+                new Thread(() -> {
+                    Manager.getInstance().resumeService(context, Manager.CONTEXT_BATTERY);
+                }).start();
+
                 break;
             case Intent.ACTION_POWER_DISCONNECTED:
                 Log.i("Freenet", "Pausing service from power change");
-                Manager.getInstance().pauseService(context, Manager.CONTEXT_BATTERY);
+                new Thread(() -> {
+                    Manager.getInstance().pauseService(context, Manager.CONTEXT_BATTERY);
+                }).start();
                 break;
         }
     }


### PR DESCRIPTION
Avoid running into NetworkOnMainThread exception when removing charger when app is open.

Fixes #33 