### PR TITLE
Stop node on low battery

### DIFF
--- a/app/src/main/java/org/freenetproject/mobile/receivers/BatteryLevelReceiver.java
+++ b/app/src/main/java/org/freenetproject/mobile/receivers/BatteryLevelReceiver.java
@@ -1,0 +1,19 @@
+package org.freenetproject.mobile.receivers;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.util.Log;
+
+import org.freenetproject.mobile.services.node.Manager;
+
+public class BatteryLevelReceiver extends BroadcastReceiver
+{
+    @Override
+    public void onReceive(Context context, Intent intent)
+    {
+        Log.i("Freenet", "Stopping service from low battery level");
+        Manager.getInstance().stopService(context);
+    }
+}
+

--- a/app/src/main/java/org/freenetproject/mobile/services/node/Service.java
+++ b/app/src/main/java/org/freenetproject/mobile/services/node/Service.java
@@ -14,6 +14,7 @@ import android.util.Log;
 import androidx.preference.PreferenceManager;
 
 import org.freenetproject.mobile.proxy.Simple;
+import org.freenetproject.mobile.receivers.BatteryLevelReceiver;
 import org.freenetproject.mobile.receivers.PowerConnectionReceiver;
 import org.freenetproject.mobile.ui.notification.Notification;
 
@@ -29,12 +30,16 @@ public class Service extends android.app.Service {
 
         SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(getBaseContext());
         Boolean preserveBattery = sharedPreferences.getBoolean("preserve_battery", true);
+
         // Register power connection receiver
         if (preserveBattery) {
             IntentFilter powerConnectedFilter = new IntentFilter();
             powerConnectedFilter.addAction(Intent.ACTION_POWER_CONNECTED);
             powerConnectedFilter.addAction(Intent.ACTION_POWER_DISCONNECTED);
             registerReceiver(powerConnectionReceiver, powerConnectedFilter);
+
+            registerReceiver(new BatteryLevelReceiver(), new IntentFilter(
+                    Intent.ACTION_BATTERY_LOW));
         }
 
         Boolean preserveData = sharedPreferences.getBoolean("preserve_data",true);


### PR DESCRIPTION
Listen to ACTION_BATTERY_LOW intent and stop the node. The node will remain stopped until the user restart it.

This functionality can be disabled with "Preserve battery" setting.

Fixes #10 