### PR TITLE
Remove plugins link

### DIFF
--- a/app/src/main/assets/index.html
+++ b/app/src/main/assets/index.html
@@ -78,7 +78,6 @@
             <div class="text-gray-500 text-base mt-3 leading-loose">
                 <ul class="list-none md:list-disc">
                     <li><a href="http://127.0.0.1:8888/config/node">Configure Security and Network »</a></li>
-                    <li><a href="http://127.0.0.1:8888/plugins">Install plugins to enhance Freenet »</a></li>
                     <li><a href="http://127.0.0.1:8888/">Go to Admin Dashboard »</a></li>
                 </ul>
             </div>


### PR DESCRIPTION
Removes broken link to missing plugins page. Fixes #100.

Additional notes: Fred's plugin page won't be used for enabling bundled app plugins as these will be handled by in-app configuration screens.